### PR TITLE
Updated the CloudFormation template 

### DIFF
--- a/FSx_Alerting/FSx_ONTAP_Alerting/README.md
+++ b/FSx_Alerting/FSx_ONTAP_Alerting/README.md
@@ -104,6 +104,8 @@ To install the program using the CloudFormation template, you will need to do th
 |ImplementWatchdogAsLambda|If set to "true" a Lambda function will be created that will allow the CloudWatch alarm to publish an alert to an SNS topic in another region. Only necessary if the SNS topic is in another region since CloudWatch cannot send alerts across regions.|
 |WatchdogRoleArn|The ARN of the role assigned to the Lambda function that the watchdog CloudWatch alarm will use to publish SNS alerts with. The only required permission is to publish to the SNS topic listed above, although highly recommended that you also add the AWS managed "AWSLambdaBasicExecutionRole" policy that allows the Lambda function to create and write to a CloudWatch log stream so it can provide diagnostic output of something goes wrong. Only required if creating a CloudWatch alert, implemented as a Lambda function, and you want to provide your own role. If left blank a role will be created for you if needed.|
 |LambdaRoleArn|The ARN of the role that the Lambda function will use. This role must have the permissions listed in the [Create an AWS Role](#create-an-aws-role) section below. If left blank a role will be created for you.|
+|lambdaLayerArn|The ARN of the Lambda Layer to use for the Lambda function. This is only needed if you want to use an existing Lambda layer, typically from a previous installation of this program. If no ARN is provided, a Lambda Layer will be created for you from the lambda_layer.zip found in your S3 bucket.|
+|accountId|An account ID you want added to the FSxN file system name in alerts. This purely for documentation purposes and serves no other purpose.|
 |CreateSecretsManagerEndpoint|Set to "true" if you want to create a Secrets Manager endpoint. **NOTE:** If a SecretsManager Endpoint already exist for the specified Subnet the endpoint creation will fail, causing the entire CloudFormation stack to fail. Please read the [Endpoints for AWS services](#endpoints-for-aws-services) for more information.|
 |CreateSNSEndpoint|Set to "true" if you want to create an SNS endpoint. **NOTE:** If a SNS Endpoint already exist for the specified Subnet the endpoint creation will fail, causing the entire CloudFormation stack to fail. Please read the [Endpoints for AWS services](#endpoints-for-aws-services) for more information.|
 |CreateCWEndpoint|Set to "true" if you want to create a CloudWatch endpoint. **NOTE:** If a CloudWatch Endpoint already exist for the specified Subnet the endpoint creation will fail, causing the entire CloudFormation stack to fail. Please read the [Endpoints for AWS services](#endpoints-for-aws-services) for more information.|
@@ -134,6 +136,11 @@ click on "View CloudWatch Logs" link. Once on this page, click on the first LogS
 If there are any errors, they will be displayed there. If you can't figure out what is causing an error,
 please create an issue on the [Issues](https://github.com/NetApp/FSx-ONTAP-monitoring/issues) section
 in this repository and someone will help you.
+
+### Deploying the CloudFormation stack via the command line
+If you want to deploy this program from the command line, you can use the [deployStack](deployStack) script
+found in this repository. It takes various options to set the required parameters in the
+stack. If you run the script without any parameters, it will display the usage information.
 
 ---
 

--- a/FSx_Alerting/FSx_ONTAP_Alerting/cloudformation.yaml
+++ b/FSx_Alerting/FSx_ONTAP_Alerting/cloudformation.yaml
@@ -21,7 +21,9 @@ Metadata:
           - implementWatchdogAsLambda
           - watchdogRoleArn
           - LambdaRoleArn
-      - Label: 
+          - lambdaLayerArn
+          - accountId
+      - Label:
           default: "AWS Endpoint Options"
         Parameters:
           - createSecretsManagerEndpoint
@@ -82,8 +84,12 @@ Metadata:
         default: "Implement Watchdog as Lambda Function"
       watchdogRoleArn:
         default: "Watchdog Role ARN"
+      lambdaLayerArn:
+        default: "Lambda Layer ARN"
       LambdaRoleArn:
         default: "Lambda Role ARN"
+      accountId:
+        default: "Account ID"
       createSecretsManagerEndpoint:
         default: "Create Secrets Manager Endpoint"
       createSNSEndpoint:
@@ -241,6 +247,16 @@ Parameters:
     Type: String
     Default: ""
 
+  lambdaLayerArn:
+    Description: "The ARN of the Lambda Layer to use for the Lambda function. This is only needed if you want to use an existing Lambda layer, typically from a previous installation of this program. If no ARN is provided, a Lambda Layer will be created for you from the lambda_layer.zip found in your S3 bucket."
+    Type: String
+    Default: ""
+
+  accountId:
+    Description: "An account ID you want added to the FSxN file system name in alerts. This purely for documentation purposes and serves no other purpose."
+    Type: String
+    Default: ""
+
   checkInterval:
     Description: "The interval, in minutes, between checks."
     Type: Number
@@ -376,6 +392,7 @@ Conditions:
   CreateWatchdogRole: !And [!Equals [!Ref watchdogRoleArn, ""], !Equals [!Ref implementWatchdogAsLambda, "true"]]
   CreateLambdaRoleWithCW: !And [!Equals [!Ref LambdaRoleArn, ""], !Not [!Equals [!Ref cloudWatchLogGroupArn, ""]]]
   CreateLambdaRoleWithoutCW: !And [!Equals [!Ref LambdaRoleArn, ""], !Equals [!Ref cloudWatchLogGroupArn, ""]]
+  CreateLambdaLayer: !Equals [!Ref lambdaLayerArn, ""]
 
 Resources:
   SecretManagerEndpoint:
@@ -637,6 +654,7 @@ Resources:
 
   LambdaLayer:
     Type: "AWS::Lambda::LayerVersion"
+    Condition: CreateLambdaLayer
     Properties:
       LayerName: !Sub "MOS-${AWS::StackName}"
       Content:
@@ -656,7 +674,7 @@ Resources:
       PackageType: "Zip"
       Runtime: "python3.12"
       Layers:
-        - !GetAtt LambdaLayer.LayerVersionArn
+        - !If [CreateLambdaLayer, !GetAtt LambdaLayer.LayerVersionArn, !Ref lambdaLayerArn]
       Handler: "index.lambda_handler"
       Timeout: 60
       Environment:
@@ -670,6 +688,7 @@ Resources:
           snsTopicArn: !Ref snsTopicArn
           sendSnsFunctionName: !Sub "monitor-ontap-services-watchdog-${AWS::StackName}"
           cloudWatchLogGroupArn: !Ref cloudWatchLogGroupArn
+          awsAccountId: !Ref accountId
 
           initialVersionChangeAlert: !Ref versionChangeAlert
           initialFailoverAlert: !Ref failoverAlert
@@ -713,8 +732,8 @@ Resources:
           # "matching conditions."  It is intended to be run as a Lambda function, but
           # can be run as a standalone program.
           #
-          # Version: v2.3
-          # Date: 2025-06-03-16:05:04
+          # Version: v3.1
+          # Date: 2025-06-10-17:54:22
           ################################################################################
           
           import json

--- a/FSx_Alerting/FSx_ONTAP_Alerting/deployStack
+++ b/FSx_Alerting/FSx_ONTAP_Alerting/deployStack
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+# This script is used to deploy the CloudFormation stack for monitoring
+# ONTAP system.
+################################################################################
+#
+################################################################################
+# This function just prints the usage of the script and exits.
+################################################################################
+usage () {
+  cat <<EOF >&2
+Usage: $(basename $0) -o <ontapServer> -b <bucket> -s <subnets> -g <securityGroup> -t <snsTopicArn> -a <secretArn> [-c <matchingConditionsFile>] [-r <roleArn>] [-i <accountId>] [-w <true|false>] [-x <watchdogRoleArn>] [-v checkInterval] [-l <lambdaLayerArn>]
+    -o <ontapServer> The name of the ONTAP system to monitor
+    -b <bucket> The S3 bucket where the CloudFormation template is stored
+    -s <subnets> Comma-separated list of subnet IDs (not ARNs).
+    -g <securityGroup> The security group ID to use (not ARN). Just needs to allow outbound over TCP port 443.
+    -t <snsTopicArn> The ARN of the SNS topic for notifications.
+    -a <secretArn> The ARN of the Secrets Manager secret for credentials.
+    -c <matchingConnditionsFile> The matching conditions file (optional).
+    -i <accountId> The account ID that will be added to the cluster name for identification puproses.
+    -r <roleArn> The Arn of the role to use for the Monitoring Lambda function (optional).
+    -w <true|false> Create a watchdog alarm (optional, default is true).
+    -x <watchdogRoleArn> The ARN of the role to use for the watchdog Lambda function (optional).
+    -v <checkInterval> The interval in minutes to check the ONTAP system (optional, the default is 15 minutes).
+    -l <lambdaLayerArn> The ARN of the Lambda layer to use (optional).
+EOF
+  exit 1
+}
+
+################################################################################
+# Main code starts here.
+################################################################################
+#
+# Process command line arguments.
+watchdog="true"
+checkInterval=15
+while getopts "ho:b:s:g:t:a:c:i:r:w:x:v:l:" opt; do
+  case $opt in
+    o) ontapServer="$OPTARG" ;;
+    b) bucket="$OPTARG" ;;
+    c) matchingConditionsFile="$OPTARG" ;;
+    s) subnets="'$OPTARG'" ;;
+    g) securityGroup="$OPTARG" ;;
+    t) snsTopicArn="$OPTARG" ;;
+    a) secretArn="$OPTARG" ;;
+    i) accountId="$OPTARG" ;;
+    r) roleArn="$OPTARG" ;;
+    w) watchdog="$(echo $OPTARG | tr '[A-Z]' '[a-z]')" ;;
+    x) watchdogRoleArn="$OPTARG" ;;
+    v) checkInterval="$OPTARG" ;;
+    l) lambdaLayerArn="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [[ -z "$ontapServer" || -z "$bucket" || -z "$subnets" || -z "$securityGroup" || -z "$snsTopicArn" || -z "$secretArn" ]]; then
+  echo "Error: Missing required arguments." >&2
+  usage
+fi
+
+if [[ $watchdog != "true" && $watchdog != "false" ]]; then
+  echo "Error: Invalid value for -w option. Use 'true' or 'false'." >&2
+  usage
+fi
+#
+# Create a CloudFormation stack name that isn't too long.
+stackName=MOS-$(echo $ontapServer | tr  -s '.' '-')
+stackName=${stackName:0:29}
+
+if [ ! -z "$matchingConditionsFile" ]; then
+  if aws s3 cp $matchingConditionsFile s3://$bucket/${ontapServer}-conditions; then
+    :
+  else
+    echo "Error, could not copy matching conditions file to S3 bucket." >&2
+    echo "Exiting..." >&2
+    exit 1
+  fi
+fi
+#
+# The script got too big now it has to be stored in a S3 bucket.
+if aws s3 cp cloudformation.yaml s3://$bucket; then
+    :
+  else
+    echo "Error, could not copy cloudformation.yaml to S3 bucket." >&2
+    echo "Exiting..." >&2
+    exit 1
+fi
+#
+# Since the only reason to provide a watchdog role ARN is to attach it to the Lambda function
+# that it will use to publish the SNS topic. Otherwise, assume the watchdog ClouedWatch
+# alarm will publish to the topic directly.
+if [ ! -z "$watchdogRoleArn" ]; then
+  implementWatchdogAsLambda="true"
+else
+  implementWatchdogAsLambda="false"
+fi
+#
+# Deploy the stack
+aws cloudformation create-stack --stack-name $stackName --template-url https://s3.amazonaws.com/${bucket}/cloudformation-acct.yaml \
+  --capabilities CAPABILITY_NAMED_IAM --parameters \
+  ParameterKey=OntapAdminSever,ParameterValue=$ontapServer \
+  ParameterKey=subNetIds,ParameterValue="$subnets" \
+  ParameterKey=securityGroupIds,ParameterValue=$securityGroup \
+  ParameterKey=snsTopicArn,ParameterValue=$snsTopicArn \
+  ParameterKey=secretArn,ParameterValue=$secretArn \
+  ParameterKey=s3BucketName,ParameterValue=$bucket \
+  ParameterKey=accountId,ParameterValue=$accountId  \
+  ParameterKey=createWatchdogAlarm,ParameterValue="$watchdog" \
+  ParameterKey=implementWatchdogAsLambda,ParameterValue="$implementWatchdogAsLambda" \
+  ParameterKey=watchdogRoleArn,ParameterValue="$watchdogRoleArn" \
+  ParameterKey=checkInterval,ParameterValue="$checkInterval" \
+  ParameterKey=lambdaLayerArn,ParameterValue="$lambdaLayerArn" \
+  ParameterKey=LambdaRoleArn,ParameterValue="$roleArn"

--- a/FSx_Alerting/FSx_ONTAP_Alerting/updateMonOntapServiceCFTemplate
+++ b/FSx_Alerting/FSx_ONTAP_Alerting/updateMonOntapServiceCFTemplate
@@ -5,7 +5,7 @@
 # the template.
 #################################################################################
 
-majorVersionNum=2
+majorVersionNum=3
 file="monitor_ontap_services.py"
 
 tmpfile1=$(mktemp /tmp/tmpfile1.XXXXXX)


### PR DESCRIPTION
Update the CloudFormation template to allow the user to specify the 'accountID' that is added to the file system name in the alert messages. Also added the ability to specify a Lambda Layer ARN so you can reuse one from a previous deployment, as opposed to creating a new version of the Lambda Layer for each deployment.